### PR TITLE
Add CSS reset

### DIFF
--- a/website/src/learn-content/connecting-letters.svx
+++ b/website/src/learn-content/connecting-letters.svx
@@ -7,7 +7,7 @@ order: 8
 
 <script lang="ts">
     import type { OutlineObject } from '$lib/types.ts'
-    import OutlineCardAnimated from '$lib/cards/OutlineCardAnimated.svelte'
+    import OutlineCardGrid from '$lib/cards/OutlineCardGrid.svelte'
     import WordDisemvoweler from '$lib/disemvoweler/WordDisemvoweler.svelte'
     import WordToOutline from '$lib/WordToOutline.svelte'
 </script> 
@@ -29,7 +29,7 @@ With each step of the process, you are saving time. Going from 'rose' to 'rs' cu
 
 The savings are even better with [special outlines](/learn/special-outlines). Let's take the one for 'conference' as an example.
 
-<OutlineCardAnimated outlineOrWord="conference" --width={"50%"} />
+<OutlineCardGrid wordsAndPhrases={["conference"]} />
 
 Look at that. One motion of the pen. Eleven would be needed to write it out in longhand. Even the disemvoweled version takes seven.
 

--- a/website/src/learn-content/letter-positioning-and-hierarchy.svx
+++ b/website/src/learn-content/letter-positioning-and-hierarchy.svx
@@ -6,7 +6,6 @@ order: 5
 ---
 
 <script>
-    import OutlineCardAnimated from '$lib/cards/OutlineCardAnimated.svelte'
 	import OutlineCardGrid from '$lib/cards/OutlineCardGrid.svelte'
 </script> 
 
@@ -30,7 +29,7 @@ If a word contains one or more of these letters you must take them into account 
 
 Take 'what' as example (which becomes 'wt' when written in Teeline). Even though the first letter is 'w', which as a default sits on the line, the other letter is a 't', which takes precedence. The right place to put the word is therefore _above_ the line.
 
-<OutlineCardAnimated outlineOrWord="what" --width={"50%"} />
+<OutlineCardGrid wordsAndPhrases={["what"]} />
 
 The same shape on the line would translate to 'wd'.
 

--- a/website/src/learn-content/punctuation.svx
+++ b/website/src/learn-content/punctuation.svx
@@ -6,7 +6,6 @@ order: 4
 ---
 
 <script>
-    import OutlineCardAnimated from '$lib/cards/OutlineCardAnimated.svelte'
     import OutlineCardGrid from '$lib/cards/OutlineCardGrid.svelte'
     import ShorthandPassage from '$lib/ShorthandPassage.svelte'
 </script>
@@ -24,7 +23,8 @@ Another key punctuation mark in Teeline denotes capital letters. They look like 
 
 Here is an example of it being used in the [special outline](/learn/special-outlines) for **'English'**:
 
-<OutlineCardAnimated outlineOrWord="English" --width={"50%"} />
+<OutlineCardGrid wordsAndPhrases={["English"]} />
+
 
 The symbol is especially useful for proper nouns and people's names. 
 

--- a/website/src/learn-content/punctuation.svx
+++ b/website/src/learn-content/punctuation.svx
@@ -25,7 +25,6 @@ Here is an example of it being used in the [special outline](/learn/special-outl
 
 <OutlineCardGrid wordsAndPhrases={["English"]} />
 
-
 The symbol is especially useful for proper nouns and people's names. 
 
 It's unnecessary to capitalise the first letter of a sentence in Teeline as it's clear, thanks to the period slash, where one sentence ends and another begins. 

--- a/website/src/lib/SpeedToggle.svelte
+++ b/website/src/lib/SpeedToggle.svelte
@@ -28,7 +28,6 @@
 		border-radius: 36px;
 		display: inline-block;
 		overflow: hidden;
-		background: #cccccc;
 		margin: 0 0.5rem;
 	}
 

--- a/website/src/lib/WordToOutline.svelte
+++ b/website/src/lib/WordToOutline.svelte
@@ -22,6 +22,6 @@
 		column-gap: 3rem;
 		align-items: center;
 		justify-content: center;
-		margin: 5rem auto;
+		margin: 0 auto 2rem auto;
 	}
 </style>

--- a/website/src/lib/WordToOutline.svelte
+++ b/website/src/lib/WordToOutline.svelte
@@ -10,7 +10,7 @@
 		<WordDisemvoweler {word} />
 	</div>
 	<div>
-		<OutlineCardAnimated outlineOrWord={word} displayName={false} --width={'100%'} />
+		<OutlineCardAnimated outlineOrWord={word} displayName={false} />
 	</div>
 </div>
 

--- a/website/src/lib/cards/OutlineCardAnimated.svelte
+++ b/website/src/lib/cards/OutlineCardAnimated.svelte
@@ -32,7 +32,6 @@
 	.card {
 		box-shadow: 0px 0px 10px 1px #e1e1e1;
 		border-radius: 10px;
-		width: var(--width);
 		padding: 1rem 1rem 2rem 1rem;
 		margin: 0 auto;
 		max-width: 200px;

--- a/website/src/lib/cards/OutlineCardAnimated.svelte
+++ b/website/src/lib/cards/OutlineCardAnimated.svelte
@@ -33,7 +33,7 @@
 		box-shadow: 0px 0px 10px 1px #e1e1e1;
 		border-radius: 10px;
 		width: var(--width);
-		padding: 10% 10% 20% 10%;
+		padding: 1rem 1rem 2rem 1rem;
 		margin: 0 auto;
 		max-width: 200px;
 		font-family: 'Handwriting', sans-serif;

--- a/website/src/lib/cards/OutlineCardGrid.svelte
+++ b/website/src/lib/cards/OutlineCardGrid.svelte
@@ -33,5 +33,6 @@
 		justify-content: center;
 		column-gap: 2rem;
 		row-gap: 2rem;
+		margin-bottom: 2rem;
 	}
 </style>

--- a/website/src/lib/disemvoweler/PassageDisemvoweler.svelte
+++ b/website/src/lib/disemvoweler/PassageDisemvoweler.svelte
@@ -25,6 +25,7 @@
 		text-align: center;
 		box-shadow: 0px 0px 10px 1px #e1e1e1;
 		border-radius: 30px;
+		margin-bottom: 2rem;
 	}
 	textarea {
 		font-size: 2rem;

--- a/website/src/lib/layout/Footer.svelte
+++ b/website/src/lib/layout/Footer.svelte
@@ -17,7 +17,7 @@
 	}
 
 	.footer-content {
-		margin: 100px 0;
+		padding: 50px 0;
 	}
 
 	p {

--- a/website/src/lib/layout/Header.svelte
+++ b/website/src/lib/layout/Header.svelte
@@ -23,7 +23,7 @@
 
 	h1 {
 		text-align: center;
-		margin: 50px 0 0 0;
+		margin: 2rem 0 -2rem 0;
 	}
 
 	h1 a {
@@ -34,7 +34,7 @@
 	.tagline {
 		text-align: center;
 		font-size: 2rem;
-		margin-bottom: 2rem;
+		margin: 0 0 1rem 0;
 	}
 
 	ul {

--- a/website/src/lib/styles/global.css
+++ b/website/src/lib/styles/global.css
@@ -27,8 +27,15 @@
 
 p {
 	font-size: var(--regular-font-size);
-	margin: 2rem 0;
+	margin: 0 0 2rem 0;
 	line-height: 1.5;
+}
+
+h1,
+h2,
+h3,
+h4 {
+	margin: 0 0 2rem 0;
 }
 
 h1 {
@@ -38,6 +45,7 @@ h1 {
 
 h2 {
 	font-size: 4rem;
+	line-height: 1;
 }
 
 h3 {
@@ -78,6 +86,7 @@ figure {
 	display: block;
 	margin-left: auto;
 	margin-right: auto;
+	margin-bottom: 1rem;
 	text-align: center;
 	color: gray;
 }

--- a/website/src/lib/styles/reset.css
+++ b/website/src/lib/styles/reset.css
@@ -1,0 +1,43 @@
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
+* {
+	margin: 0;
+}
+html,
+body {
+	height: 100%;
+}
+body {
+	line-height: 1.5;
+	-webkit-font-smoothing: antialiased;
+}
+img,
+picture,
+video,
+canvas,
+svg {
+	display: block;
+	max-width: 100%;
+}
+input,
+button,
+textarea,
+select {
+	font: inherit;
+}
+p,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	overflow-wrap: break-word;
+}
+#root,
+#__next {
+	isolation: isolate;
+}

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import '$lib/styles/reset.css';
 	import '$lib/styles/global.css';
 	import Header from '../lib/layout/Header.svelte';
 	import Footer from '../lib/layout/Footer.svelte';

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -52,6 +52,7 @@
 		background-color: white;
 		padding: 0.5rem 0;
 		box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+		line-height: 1;
 	}
 	@media (min-width: 768px) {
 		.speed-toggle-container {


### PR DESCRIPTION
Belatedly adds [a CSS reset](https://www.joshwcomeau.com/css/custom-css-reset/) to the site so that it's starting from zero, so to speak.

This has required some adjustments to the existing styling and also been a nice excuse to use the [`OutlineCardGrid`](https://github.com/gonzo-engineering/teeline-online/pull/231) component more widely, which further tidies up the MDsveX files.