### PR TITLE
Allow users to control animation/wpm speed

### DIFF
--- a/website/src/lib/ShorthandPassage.svelte
+++ b/website/src/lib/ShorthandPassage.svelte
@@ -17,7 +17,6 @@
 				{outlineObject}
 				isStandalone={false}
 				precedingOutlinesLength={inferPrecedingOutlinesLength(outlineObjects, i)}
-				drawingSpeed={900}
 			/>
 			{#if showMeanings}
 				<OutlineDetails {outlineObject} />

--- a/website/src/lib/SpeedToggle.svelte
+++ b/website/src/lib/SpeedToggle.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { user } from '$lib/stores/userStore';
+	import { wpms } from '../scripts/speed';
+	const wpmOptions = wpms.map((wpm) => wpm.speed);
+</script>
+
+<div class="settings">
+	<div class="select-wrapper">
+		<select bind:value={$user.wpm}>
+			{#each wpmOptions as wpmOption}
+				<option value={wpmOption}>{wpmOption}</option>
+			{/each}
+		</select>
+	</div>
+	words per minute
+</div>
+
+<style>
+	.settings {
+		font-size: var(--regular-font-size);
+		text-align: center;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+
+	.select-wrapper {
+		border-radius: 36px;
+		display: inline-block;
+		overflow: hidden;
+		background: #cccccc;
+		margin: 0 0.5rem;
+	}
+
+	select {
+		height: 2rem;
+		padding: 0 0.5rem;
+		font-size: 1rem;
+		font-weight: bold;
+		border: none;
+	}
+	select:focus {
+		outline: none;
+	}
+</style>

--- a/website/src/lib/layout/Header.svelte
+++ b/website/src/lib/layout/Header.svelte
@@ -1,21 +1,23 @@
 <script lang="ts">
 	import { user } from '$lib/stores/userStore';
+	import { wpms } from '../../scripts/speed';
 	import HeaderLink from './HeaderLink.svelte';
 
 	const setWpm = (wpm: number) => {
 		user.set({ wpm });
 	};
 
-	const wpmOptions = [40, 60, 80, 100, 120];
+	const wpmOptions = wpms.map((wpm) => wpm.speed);
 </script>
 
 <header>
-	<div>Animation speed: {$user.wpm} words per minute</div>
-	{#each wpmOptions as wpmOption}
-		<button on:click={() => setWpm(wpmOption)}>
-			{wpmOption}
-		</button>
-	{/each}
+	<div>
+		Animation speed: <select bind:value={$user.wpm}>
+			{#each wpmOptions as wpmOption}
+				<option value={wpmOption}>{wpmOption}</option>
+			{/each}
+		</select> words per minute
+	</div>
 	<h1><a href="/">teeline.online</a></h1>
 	<div class="tagline">Very (short)handy</div>
 	<nav>
@@ -32,6 +34,12 @@
 	header {
 		margin: 0 0 50px 0;
 		width: 100%;
+	}
+
+	select {
+		height: 2rem;
+		font-size: 1rem;
+		border: none;
 	}
 
 	h1 {

--- a/website/src/lib/layout/Header.svelte
+++ b/website/src/lib/layout/Header.svelte
@@ -1,23 +1,8 @@
 <script lang="ts">
-	import { user } from '$lib/stores/userStore';
-	import { wpms } from '../../scripts/speed';
 	import HeaderLink from './HeaderLink.svelte';
-
-	const setWpm = (wpm: number) => {
-		user.set({ wpm });
-	};
-
-	const wpmOptions = wpms.map((wpm) => wpm.speed);
 </script>
 
 <header>
-	<div>
-		Animation speed: <select bind:value={$user.wpm}>
-			{#each wpmOptions as wpmOption}
-				<option value={wpmOption}>{wpmOption}</option>
-			{/each}
-		</select> words per minute
-	</div>
 	<h1><a href="/">teeline.online</a></h1>
 	<div class="tagline">Very (short)handy</div>
 	<nav>
@@ -34,12 +19,6 @@
 	header {
 		margin: 0 0 50px 0;
 		width: 100%;
-	}
-
-	select {
-		height: 2rem;
-		font-size: 1rem;
-		border: none;
 	}
 
 	h1 {

--- a/website/src/lib/layout/Header.svelte
+++ b/website/src/lib/layout/Header.svelte
@@ -1,8 +1,21 @@
 <script lang="ts">
+	import { user } from '$lib/stores/userStore';
 	import HeaderLink from './HeaderLink.svelte';
+
+	const setWpm = (wpm: number) => {
+		user.set({ wpm });
+	};
+
+	const wpmOptions = [40, 60, 80, 100, 120];
 </script>
 
 <header>
+	<div>Animation speed: {$user.wpm} words per minute</div>
+	{#each wpmOptions as wpmOption}
+		<button on:click={() => setWpm(wpmOption)}>
+			{wpmOption}
+		</button>
+	{/each}
 	<h1><a href="/">teeline.online</a></h1>
 	<div class="tagline">Very (short)handy</div>
 	<nav>

--- a/website/src/lib/outlineSVGs/OutlineSVG.svelte
+++ b/website/src/lib/outlineSVGs/OutlineSVG.svelte
@@ -4,6 +4,7 @@
 	import { inferPrecedingLinesLength } from '../../scripts/line-length-inference';
 	import Lines from './Lines.svelte';
 	import { user } from '$lib/stores/userStore';
+	import { speeds } from '../../scripts/speed';
 
 	let {
 		outlineObject,
@@ -40,7 +41,7 @@
 			{line}
 			{precedingOutlinesLength}
 			previousLinesLength={inferPrecedingLinesLength(outlineObject, index)}
-			drawingSpeed={$user.wpm * 15}
+			drawingSpeed={speeds[$user.wpm]}
 		/>
 	{/each}
 </svg>

--- a/website/src/lib/outlineSVGs/OutlineSVG.svelte
+++ b/website/src/lib/outlineSVGs/OutlineSVG.svelte
@@ -3,6 +3,7 @@
 	import { prettify } from '../../scripts/helpers';
 	import { inferPrecedingLinesLength } from '../../scripts/line-length-inference';
 	import Lines from './Lines.svelte';
+	import { user } from '$lib/stores/userStore';
 
 	let {
 		outlineObject,
@@ -39,7 +40,7 @@
 			{line}
 			{precedingOutlinesLength}
 			previousLinesLength={inferPrecedingLinesLength(outlineObject, index)}
-			{drawingSpeed}
+			drawingSpeed={$user.wpm * 15}
 		/>
 	{/each}
 </svg>

--- a/website/src/lib/stores/userStore.ts
+++ b/website/src/lib/stores/userStore.ts
@@ -1,0 +1,5 @@
+import { writable } from 'svelte/store';
+
+export const user = writable({
+	wpm: 60
+});

--- a/website/src/lib/styles/global.css
+++ b/website/src/lib/styles/global.css
@@ -96,10 +96,6 @@ li {
 	padding-left: 20px;
 }
 
-input {
-	font-size: var(--regular-font-size);
-}
-
 small {
 	font-size: 0.9rem;
 }

--- a/website/src/routes/generator/+page.svelte
+++ b/website/src/routes/generator/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import SpeedToggle from '$lib/SpeedToggle.svelte';
 	import ShorthandPassage from '$lib/ShorthandPassage.svelte';
 
 	let inputText = $state('');
@@ -13,12 +14,15 @@
 </svelte:head>
 
 <div class="container">
-	<input
-		bind:value={inputText}
-		type="text"
-		class="search-input search-input-generator"
-		placeholder="Generate outlines..."
-	/>
+	<div class="input-and-settings">
+		<input
+			bind:value={inputText}
+			type="text"
+			class="search-input search-input-generator"
+			placeholder="Generate outlines..."
+		/>
+		<SpeedToggle />
+	</div>
 	<ShorthandPassage text={inputText.trim()} showMeanings={true} />
 	<div style="width: 50%; margin: auto; text-align: center;">
 		<p>This feature is a work in progress so take results with a grain of salt.</p>
@@ -31,9 +35,20 @@
 		margin: 0 auto;
 		padding-top: 2rem;
 	}
+	.input-and-settings {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		margin-bottom: 2rem;
+		gap: 1rem;
+	}
 	.search-input-generator {
-		margin: 0 auto;
 		display: block;
-		margin-bottom: 3rem;
+	}
+	@media (min-width: 768px) {
+		.input-and-settings {
+			flex-direction: row;
+		}
 	}
 </style>

--- a/website/src/routes/outlines/+page.svelte
+++ b/website/src/routes/outlines/+page.svelte
@@ -6,6 +6,7 @@
 	import { hydratedData } from '../../scripts/hydrate-outline-data';
 	import { alphabet } from '../../data/letter-hierarchy';
 	import OutlineCardGrid from '$lib/cards/OutlineCardGrid.svelte';
+	import SpeedToggle from '$lib/SpeedToggle.svelte';
 
 	let displayedOutlines: OutlineObject[] = $state(hydratedData);
 	let alphabetToggleOn: boolean = $state(false);
@@ -40,7 +41,10 @@
 			displayedOutlines = filterAndSortOutlines(outlinesToFilter, searchTerm.trim().toLowerCase());
 		}}
 	/>
-	<Toggle toggleLabel={`Only show alphabet`} toggleFunction={toggleAlphabetFilter} />
+	<div class="settings">
+		<Toggle toggleLabel="Alphabet only" toggleFunction={toggleAlphabetFilter} />
+		<SpeedToggle />
+	</div>
 </div>
 
 {#if searchTerm.length > 0 && displayedOutlines.length > 0}
@@ -81,11 +85,24 @@
 	.search-term {
 		font-weight: 700;
 	}
+	.settings {
+		display: flex;
+		flex-direction: column;
+		gap: 0;
+		justify-items: center;
+		align-items: center;
+	}
 	.nothing-found-message {
 		margin: 3rem auto;
 		text-align: center;
 		font-size: 1.8rem;
 		line-height: 1.5;
 		max-width: 800px;
+	}
+	@media (min-width: 768px) {
+		.settings {
+			flex-direction: row;
+			gap: 1rem;
+		}
 	}
 </style>

--- a/website/src/scripts/speed.ts
+++ b/website/src/scripts/speed.ts
@@ -1,0 +1,132 @@
+import { convertPassageToOutlines } from './build-outline-objects';
+import { disemvowelBodyOfText } from './disemvowel';
+import { hydratedData } from './hydrate-outline-data';
+
+const hundredWords = [
+	'about',
+	'all',
+	'also',
+	'and',
+	'as',
+	'at',
+	'be',
+	'because',
+	'but',
+	'by',
+	'can',
+	'come',
+	'could',
+	'day',
+	'do',
+	'even',
+	'find',
+	'first',
+	'for',
+	'from',
+	'get',
+	'give',
+	'go',
+	'have',
+	'he',
+	'her',
+	'here',
+	'him',
+	'his',
+	'how',
+	'I',
+	'if',
+	'in',
+	'into',
+	'it',
+	'its',
+	'just',
+	'know',
+	'like',
+	'look',
+	'make',
+	'man',
+	'many',
+	'me',
+	'more',
+	'my',
+	'new',
+	'no',
+	'not',
+	'now',
+	'of',
+	'on',
+	'one',
+	'only',
+	'or',
+	'other',
+	'our',
+	'out',
+	'people',
+	'say',
+	'see',
+	'she',
+	'so',
+	'some',
+	'take',
+	'tell',
+	'than',
+	'that',
+	'the',
+	'their',
+	'them',
+	'then',
+	'there',
+	'these',
+	'they',
+	'thing',
+	'think',
+	'this',
+	'those',
+	'time',
+	'to',
+	'two',
+	'up',
+	'use',
+	'very',
+	'want',
+	'way',
+	'we',
+	'well',
+	'what',
+	'when',
+	'which',
+	'who',
+	'will',
+	'with',
+	'would',
+	'year',
+	'you',
+	'your'
+];
+
+const disemvoweledText = disemvowelBodyOfText(hundredWords.join(' '));
+
+const outlines = convertPassageToOutlines(disemvoweledText, hydratedData);
+
+const totalLength = outlines.reduce(
+	(acc, outline) => acc + outline.lines.reduce((acc, line) => acc + line.length, 0),
+	0
+);
+
+export const wpms: {
+	speed: number;
+	divider: number;
+}[] = [
+	{ speed: 40, divider: 90 },
+	{ speed: 60, divider: 60 },
+	{ speed: 80, divider: 45 },
+	{ speed: 100, divider: 36 },
+	{ speed: 120, divider: 30 },
+	{ speed: 140, divider: 25 },
+	{ speed: 160, divider: 22.5 }
+];
+
+export const speeds = wpms.reduce((acc, { speed, divider }) => {
+	const animationSpeed = totalLength / divider;
+	return { ...acc, [speed]: animationSpeed };
+}, {});

--- a/website/src/scripts/speed.ts
+++ b/website/src/scripts/speed.ts
@@ -122,8 +122,7 @@ export const wpms: {
 	{ speed: 80, divider: 45 },
 	{ speed: 100, divider: 36 },
 	{ speed: 120, divider: 30 },
-	{ speed: 140, divider: 25 },
-	{ speed: 160, divider: 22.5 }
+	{ speed: 140, divider: 25 }
 ];
 
 export const speeds = wpms.reduce((acc, { speed, divider }) => {


### PR DESCRIPTION
Finally making https://github.com/gonzo-engineering/teeline-online/issues/137 happen. We even had the logic [sketched out](https://github.com/gonzo-engineering/teeline-online/issues/137#issuecomment-1848667360) by @mxdvl! Giving [Svelte stores](https://svelte.dev/docs/svelte-store) a spin for this...

Users can now switch between different animation speeds that _roughly_ match different words per minute. This has been done by generating outlines from the 100 most common words in the English language, adding up their combined length, then mapping that to an animation speed for the outline component to use.

I've added a toggle to the /outlines and /generator pages:

![image](https://github.com/user-attachments/assets/0d90e8be-2129-4040-9eab-057c7142fbbd)

![image](https://github.com/user-attachments/assets/70fb27f8-8f00-42f1-89bc-446e06dae77f)

I did consider having the toggle accessible in a more fixed place site-wide - a settings dropdown or some such, but this felt fine for now. That said, a store opens the door to other settings for users to control (dark mode, revision preferences, etc.). If and when that happens a sticky 'settings' menu would probably be appropriate.

- https://betterprogramming.pub/what-are-svelte-stores-and-how-to-use-them-a4963968ee89