### PR TITLE
Better handling of words that end with 'y'

### DIFF
--- a/outline-svgs/alphabet/i-down-up.svg
+++ b/outline-svgs/alphabet/i-down-up.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<!-- Created using Krita: https://krita.org -->
+<svg xmlns="http://www.w3.org/2000/svg" 
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:krita="http://krita.org/namespaces/svg/krita"
+    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+    width="720pt"
+    height="720pt"
+    viewBox="0 0 720 720">
+<defs/>
+<path id="shape0" transform="translate(323.694869288778, 412.531561081471)" fill="none" stroke="#000000" stroke-width="9.6" stroke-linecap="square" stroke-linejoin="bevel" d="M0 46.7848C10.2791 38.9402 21.7294 25.8825 30.649 15.9204C33.5662 12.6624 36.9421 9.41904 39.5261 5.89129C40.5891 4.44001 46.4296 -0.800278 45.7216 0.104217Z" sodipodi:nodetypes="ccccc"/>
+</svg>

--- a/website/src/lib/scripts/outline-building/build-outline-objects.ts
+++ b/website/src/lib/scripts/outline-building/build-outline-objects.ts
@@ -76,6 +76,12 @@ export const findOrCreateOutlineObject = (
 	// we need to get the first starting point
 	const startingObject = createStartingObject(cleanedWord, lettersObjectArray);
 
+	// If last letter is 'y' replace the last letterObjectLines entry with the 'i' object
+	if (cleanedWord.slice(-1) === 'y') {
+		const iObject = findOrCreateOutlineObject('i', outlines);
+		lettersObjectArray[lettersObjectArray.length - 1] = iObject;
+	}
+
 	const letterObjectLines = lettersObjectArray.map((letterObject) => letterObject?.lines);
 
 	const { combinedLineDetails } = letterObjectLines.reduce<{

--- a/website/src/lib/scripts/outline-building/build-outline-objects.ts
+++ b/website/src/lib/scripts/outline-building/build-outline-objects.ts
@@ -3,6 +3,7 @@ import type { LineDetails, OutlineObject, SpecialOutline } from '$lib/data/inter
 import { disemvowelWord } from '../disemvowel';
 import { createStartingObject } from './calculate-starting-point';
 import { buildMultiDigitNumberObject } from './numbers/build-multi-digit-number';
+import { downUpI } from './special-endings';
 
 const checkedSpecials: SpecialOutline[] = specials;
 const punctuationRegex = /[,\/#!$%\^&\*;:{}=\-_`~()]/g;
@@ -76,10 +77,18 @@ export const findOrCreateOutlineObject = (
 	// we need to get the first starting point
 	const startingObject = createStartingObject(cleanedWord, lettersObjectArray);
 
-	// If last letter is 'y' replace the last letterObjectLines entry with the 'i' object
+	// If last letter is 'y' replace the last letterObjectLines entry with the appropriate 'i' object
 	if (cleanedWord.slice(-1) === 'y') {
-		const iObject = findOrCreateOutlineObject('i', outlines);
-		lettersObjectArray[lettersObjectArray.length - 1] = iObject;
+		// Penultimate letter
+		const penultimateLetter = cleanedWord.charAt(cleanedWord.length - 2);
+		const regularIObject = findOrCreateOutlineObject('i', outlines);
+		const downUpIObject = downUpI;
+		const lettersThatShouldBeFollowedByDownUpI = ['f', 'g', 'h', 'j', 'n', 'p', 'z'];
+		if (lettersThatShouldBeFollowedByDownUpI.includes(penultimateLetter)) {
+			lettersObjectArray[lettersObjectArray.length - 1] = downUpIObject;
+		} else {
+			lettersObjectArray[lettersObjectArray.length - 1] = regularIObject;
+		}
 	}
 
 	const letterObjectLines = lettersObjectArray.map((letterObject) => letterObject?.lines);

--- a/website/src/lib/scripts/outline-building/special-endings.ts
+++ b/website/src/lib/scripts/outline-building/special-endings.ts
@@ -1,0 +1,20 @@
+import type { OutlineObject } from '$lib/data/interfaces/interfaces';
+
+export const downUpI: OutlineObject = {
+	letterGroupings: ['i'],
+	specialOutlineMeanings: [],
+	lines: [
+		{
+			path: 'M324 459.7848c10.2791 -7.8446 21.7294 -20.9023 30.649 -30.8644c2.9172 -3.258 6.2931 -6.5014 8.8771 -10.0291c1.063 -1.4513 6.9035 -6.6916 6.1955 -5.7871',
+			length: 132,
+			start: {
+				x: 324,
+				y: 459.7848
+			},
+			end: {
+				x: 324,
+				y: 459.7848
+			}
+		}
+	]
+};


### PR DESCRIPTION
In Teeline, words that end with 'y' use the 'i' outline rather than the 'y' one. This updates the outline generation logic to account for this, and to 'flick' the 'i' in different directions depending on what the preceding letter is.

| Before    | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/fa548712-93ea-45fe-b000-f9fd84220cbc) | ![image](https://github.com/user-attachments/assets/f675df11-77b2-47ec-827c-104bcdb66486) |

![image](https://github.com/user-attachments/assets/0f90872b-b2fd-4644-afd9-7487d3c5cd2c)

Feels a bit nasty adding another outline object to handle this. Could possibly use [`svg-path-commander`](https://www.npmjs.com/package/svg-path-commander) to reverse it in a follow up?