### PR TITLE
Move speed toggle to layout

### DIFF
--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 	import Header from '../lib/layout/Header.svelte';
 	import Footer from '../lib/layout/Footer.svelte';
 	import type { Snippet } from 'svelte';
+	import SpeedToggle from '$lib/SpeedToggle.svelte';
 
 	let { children }: { children: Snippet } = $props();
 </script>
@@ -33,10 +34,22 @@
 	{@render children()}
 </main>
 <Footer />
+<div class="speed-toggle-container">
+	<SpeedToggle />
+</div>
 
 <style>
 	main {
 		width: 85vw;
 		margin: auto;
+	}
+	.speed-toggle-container {
+		position: fixed;
+		bottom: 0;
+		right: 0;
+		width: 100%;
+		background-color: white;
+		padding: 0.5rem 0;
+		box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 	}
 </style>

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -52,4 +52,16 @@
 		padding: 0.5rem 0;
 		box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 	}
+	/* Tablet media query */
+	@media (min-width: 768px) {
+		.speed-toggle-container {
+			width: fit-content;
+			height: fit-content;
+			position: fixed;
+			top: 0;
+			right: 0;
+			padding: 0.5rem 1rem;
+			border-bottom-left-radius: 0.5rem;
+		}
+	}
 </style>

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -52,7 +52,6 @@
 		padding: 0.5rem 0;
 		box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 	}
-	/* Tablet media query */
 	@media (min-width: 768px) {
 		.speed-toggle-container {
 			width: fit-content;

--- a/website/src/routes/generator/+page.svelte
+++ b/website/src/routes/generator/+page.svelte
@@ -21,7 +21,6 @@
 			class="search-input search-input-generator"
 			placeholder="Generate outlines..."
 		/>
-		<SpeedToggle />
 	</div>
 	<ShorthandPassage text={inputText.trim()} showMeanings={true} />
 	<div style="width: 50%; margin: auto; text-align: center;">

--- a/website/src/routes/outlines/+page.svelte
+++ b/website/src/routes/outlines/+page.svelte
@@ -43,7 +43,6 @@
 	/>
 	<div class="settings">
 		<Toggle toggleLabel="Alphabet only" toggleFunction={toggleAlphabetFilter} />
-		<SpeedToggle />
 	</div>
 </div>
 


### PR DESCRIPTION
This moves the animation speed toggle to the site layout, making it accessible to people at any time.

![image](https://github.com/user-attachments/assets/df84e018-9229-43e7-9653-cccc8f210cdf)

![image](https://github.com/user-attachments/assets/8dd3b1c6-3668-43ae-999a-6e01ea0abe4c)

Not fully convinced on placement but feels like the right thing to do. I almost did it in the first place (https://github.com/gonzo-engineering/teeline-online/pull/371).
