### PR TITLE
Shorthand passage line breaks

### DIFF
--- a/website/src/lib/components/ShorthandPassage.svelte
+++ b/website/src/lib/components/ShorthandPassage.svelte
@@ -12,7 +12,7 @@
 
 <div class="animation-container passage-container">
 	{#each outlineObjects as outlineObject, i}
-		<div>
+		<div class="outline">
 			<Container
 				{outlineObject}
 				isStandalone={false}
@@ -28,8 +28,17 @@
 <style>
 	.passage-container {
 		display: flex;
+		flex-wrap: wrap;
 		gap: 0;
 		margin: 50px auto;
 		justify-content: center;
+	}
+	.outline {
+		max-width: 100px;
+	}
+	@media (min-width: 768px) {
+		.outline {
+			max-width: 150px;
+		}
 	}
 </style>

--- a/website/src/routes/generator/+page.svelte
+++ b/website/src/routes/generator/+page.svelte
@@ -2,7 +2,7 @@
 	import ShorthandPassage from '$lib/components/ShorthandPassage.svelte';
 	import Toggle from '$lib/components/Toggle.svelte';
 
-	let inputText = $state('Write and be amazed');
+	let inputText = $state('Write here and be amazed');
 	let showMeanings = $state(false);
 </script>
 

--- a/website/src/routes/generator/+page.svelte
+++ b/website/src/routes/generator/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import ShorthandPassage from '$lib/components/ShorthandPassage.svelte';
+	import Toggle from '$lib/components/Toggle.svelte';
 
-	let inputText = $state('');
+	let inputText = $state('Write and be amazed');
+	let showMeanings = $state(false);
 </script>
 
 <svelte:head>
@@ -14,15 +16,11 @@
 
 <div class="container">
 	<div class="input-and-settings">
-		<input
-			bind:value={inputText}
-			type="text"
-			class="search-input search-input-generator"
-			placeholder="Generate outlines..."
-		/>
+		<div class="generator-input" bind:innerHTML={inputText} contenteditable="plaintext-only"></div>
+		<Toggle toggleFunction={() => (showMeanings = !showMeanings)} toggleLabel="Show meanings" />
 	</div>
-	<ShorthandPassage text={inputText.trim()} showMeanings={true} />
-	<div style="width: 50%; margin: auto; text-align: center;">
+	<ShorthandPassage text={inputText.trim()} {showMeanings} />
+	<div style="text-align: center;">
 		<p>This feature is a work in progress so take results with a grain of salt.</p>
 	</div>
 </div>
@@ -41,8 +39,11 @@
 		margin-bottom: 2rem;
 		gap: 1rem;
 	}
-	.search-input-generator {
-		display: block;
+	.generator-input {
+		padding: 1rem 2rem;
+		border: 1px solid #e1e1e1;
+		border-radius: 2rem;
+		font-size: 1.2rem;
 	}
 	@media (min-width: 768px) {
 		.input-and-settings {


### PR DESCRIPTION
This adjusts the `ShorthandPassage` component to wrap to new lines, making for a more pleasant reading experience and opens the door to much longer passages.

| Before   | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/5ce2de63-1fe9-428b-9559-331bed89d87d) | ![image](https://github.com/user-attachments/assets/37346725-f670-4370-9449-b1cc928c4632) |

As the old saying goes, groovy, baby.

The changes here also prompted a little rejig of the generator page, with a 'show meanings' toggle and an [`contentEditable`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable) div replacing the old input. The main appeal here is that the box automatically changes size depending on the text.

![image](https://github.com/user-attachments/assets/768083e4-c68c-4a31-a500-ffd64ad474c4)

Plus looks pretty sharp with longer passages now:

![image](https://github.com/user-attachments/assets/28266089-404e-4389-91a9-1d9859bcc99c)

Resolves https://github.com/gonzo-engineering/teeline-online/issues/382.