### PR TITLE
Fix generator bugs

### DIFF
--- a/website/src/routes/generator/+page.svelte
+++ b/website/src/routes/generator/+page.svelte
@@ -3,6 +3,7 @@
 	import Toggle from '$lib/components/Toggle.svelte';
 
 	let inputText = $state('Write here and be amazed');
+	let textForPassage = $derived(inputText.trim().replace(/\&nbsp;/g, ''));
 	let showMeanings = $state(false);
 </script>
 
@@ -16,10 +17,10 @@
 
 <div class="container">
 	<div class="input-and-settings">
-		<div class="generator-input" bind:innerHTML={inputText} contenteditable="plaintext-only"></div>
+		<div class="generator-input" bind:innerHTML={inputText} contenteditable="true"></div>
 		<Toggle toggleFunction={() => (showMeanings = !showMeanings)} toggleLabel="Show meanings" />
 	</div>
-	<ShorthandPassage text={inputText.trim()} {showMeanings} />
+	<ShorthandPassage text={textForPassage} {showMeanings} />
 	<div style="text-align: center;">
 		<p>This feature is a work in progress so take results with a grain of salt.</p>
 	</div>


### PR DESCRIPTION
Fixes a couple of reported issues with the generator page. First, the input wasn't working at all on Firefox. (See #386.) It looks like this is because `contenteditable="plaintext-only"` isn't supported by Firefox yet.

![image](https://github.com/user-attachments/assets/366b6b5f-db9f-4345-8cae-80ffcdf726ad)

I've switched to `contenteditable="true"` for the time being though will move back once Firefox catches up.

The other issue was 'nbsp' being included in the input text.

![image](https://github.com/user-attachments/assets/4b7d3b15-65a7-4d7d-8607-f114e38ebe64)

Have added a little pre-translation cleaning step to strip that noise out.
