### PR TITLE
Random rotation on outline cards

### DIFF
--- a/website/src/lib/components/cards/OutlineCardAnimated.svelte
+++ b/website/src/lib/components/cards/OutlineCardAnimated.svelte
@@ -17,9 +17,11 @@
 		typeof outlineOrWord === 'string'
 			? findOrCreateOutlineObject(outlineOrWord, hydratedData)
 			: outlineOrWord;
+
+	const randomRotationAngle = Math.random() * 4 - 2;
 </script>
 
-<div>
+<div style="transform: rotate({randomRotationAngle}deg);">
 	<div class="card animation-container">
 		<Container {outlineObject} drawingSpeed={900} />
 		{#if displayName}


### PR DESCRIPTION
Bringing this back. Feels more natural, and truer to the site's origins.

### Before 

<img width="1670" alt="image" src="https://github.com/user-attachments/assets/cf2eed1d-9db3-4d25-b07f-342a2dd61e14" />

### After

<img width="1675" alt="image" src="https://github.com/user-attachments/assets/cb9f6aa3-992e-4ddf-a266-2f8da1066ec0" />
