### PR TITLE
Add 'ph' to f's letter groupings

### DIFF
--- a/website/src/lib/data/outlines.json
+++ b/website/src/lib/data/outlines.json
@@ -1758,7 +1758,7 @@
 		]
 	},
 	{
-		"letterGroupings": ["f"],
+		"letterGroupings": ["f", "ph"],
 		"specialOutlineMeanings": [],
 		"lines": [
 			{


### PR DESCRIPTION
Addresses #393 by adding 'ph' to the list of letter groupings for the 'f' outline. Great catch by @Icosa-dev!

### Before (outlines actually go off-screen!)

![image](https://github.com/user-attachments/assets/4ff7a75f-cca5-4095-bf7a-136eb74f6cd6)

### After

![image](https://github.com/user-attachments/assets/281409a9-413a-4fcf-be9a-b4df21bb9314)

Placement can be a little iffy but that's a larger, separate issue captured by https://github.com/gonzo-engineering/teeline-online/issues/252.
