### PR TITLE
Replace store with state

### DIFF
--- a/website/src/lib/components/SpeedToggle.svelte
+++ b/website/src/lib/components/SpeedToggle.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-	import { user } from '$lib/stores/userStore';
+	import { user } from '$lib/global-state/global-state.svelte';
 	import { wpms } from '$lib/scripts/speed';
 	const wpmOptions = wpms.map((wpm) => wpm.speed);
 </script>
 
 <div class="settings">
 	<div class="select-wrapper">
-		<select bind:value={$user.wpm} id="speed-select" name="speed">
+		<select bind:value={user.wpm} id="speed-select" name="speed">
 			{#each wpmOptions as wpmOption}
 				<option value={wpmOption}>{wpmOption}</option>
 			{/each}

--- a/website/src/lib/components/outlineSVGs/OutlineSVG.svelte
+++ b/website/src/lib/components/outlineSVGs/OutlineSVG.svelte
@@ -3,8 +3,8 @@
 	import { prettify } from '$lib/scripts/helpers';
 	import { inferPrecedingLinesLength } from '$lib/scripts/line-length-inference';
 	import Lines from './Lines.svelte';
-	import { user } from '$lib/stores/userStore';
 	import { speeds } from '$lib/scripts/speed';
+	import { user } from '$lib/global-state/global-state.svelte';
 
 	let {
 		outlineObject,
@@ -41,7 +41,7 @@
 			{line}
 			{precedingOutlinesLength}
 			previousLinesLength={inferPrecedingLinesLength(outlineObject, index)}
-			drawingSpeed={speeds[$user.wpm]}
+			drawingSpeed={speeds[user.wpm]}
 		/>
 	{/each}
 </svg>

--- a/website/src/lib/global-state/global-state.svelte.ts
+++ b/website/src/lib/global-state/global-state.svelte.ts
@@ -1,0 +1,7 @@
+export const user = $state({
+	wpm: 60
+});
+
+export const setWPM = (newWPM: number) => {
+	user.wpm = newWPM;
+};

--- a/website/src/lib/global-state/global-state.svelte.ts
+++ b/website/src/lib/global-state/global-state.svelte.ts
@@ -1,7 +1,3 @@
-export const user = $state({
+export const user: { wpm: number } = $state({
 	wpm: 60
 });
-
-export const setWPM = (newWPM: number) => {
-	user.wpm = newWPM;
-};

--- a/website/src/lib/stores/userStore.ts
+++ b/website/src/lib/stores/userStore.ts
@@ -1,5 +1,0 @@
-import { writable } from 'svelte/store';
-
-export const user = writable({
-	wpm: 60
-});


### PR DESCRIPTION
Little refactor to use Svelte 5 runes, rather than stores, to handle user state. With `blah.svelte.ts` files now we can pass state around more freely, and I think it's easier to read and work with.